### PR TITLE
Add QueryParams-based filtering with caller-controlled binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,16 @@ type UserModel struct {
 func GetUsers(c *gin.Context) {
 	var users []UserModel
 	var usersCount int64
+	var params filter.QueryParams
+
+	if err := c.ShouldBindQuery(&params); err != nil {
+		c.JSON(http.StatusBadRequest, err.Error())
+		return
+	}
+
 	db, err := gorm.Open(sqlite.Open("gorm.db"), &gorm.Config{})
 	err := db.Model(&UserModel{}).Scopes(
-		filter.FilterByQuery(c, filter.ALL),
+		filter.FilterByQueryParams(params, filter.ALL),
 	).Count(&usersCount).Find(&users).Error
 	if err != nil {
 		c.JSON(http.StatusBadRequest, err.Error())
@@ -46,11 +53,11 @@ func GetUsers(c *gin.Context) {
 	c.JSON(http.StatusOK, serializer.Response())
 }
 ```
-Any filter combination can be used here `filter.PAGINATION|filter.ORDER_BY` e.g. **Important note:** GORM model should be initialize first for DB, otherwise filter and search won't work
+Any filter combination can be used here `filter.PAGINATE|filter.ORDER_BY` e.g. **Important note:** GORM model should be initialize first for DB, otherwise filter and search won't work
 
 ## Request example
 ```(shell)
-curl -X GET http://localhost:8080/users?page=1&limit=10&order_by=username&order_direction=asc&filter="name:John"
+curl -X GET http://localhost:8080/users?page=1&page_size=10&order_by=username&order_direction=asc&filter="name:John"
 ```
 
 ## Supported filter operators

--- a/gin-gorm-filter.go
+++ b/gin-gorm-filter.go
@@ -18,14 +18,15 @@ import (
 	"gorm.io/gorm/schema"
 )
 
-type queryParams struct {
+// QueryParams contains supported filter options parsed from request query parameters.
+type QueryParams struct {
 	Search         string   `form:"search"`
 	Filter         []string `form:"filter"`
 	Page           int      `form:"page,default=1"`
 	PageSize       int      `form:"page_size,default=10"`
 	All            bool     `form:"all,default=false"`
 	OrderBy        string   `form:"order_by,default=id"`
-	OrderDirection string   `form:"order_direction,default=desc,oneof=desc asc"`
+	OrderDirection string   `form:"order_direction,default=desc" binding:"oneof=desc asc"`
 }
 
 const (
@@ -41,14 +42,14 @@ var (
 	paramNameRegexp = regexp.MustCompile(`(?m)param:(\w{1,}).*`)
 )
 
-func orderBy(db *gorm.DB, params queryParams) *gorm.DB {
+func orderBy(db *gorm.DB, params QueryParams) *gorm.DB {
 	return db.Order(clause.OrderByColumn{
 		Column: clause.Column{Name: params.OrderBy},
 		Desc:   params.OrderDirection == "desc"},
 	)
 }
 
-func paginate(db *gorm.DB, params queryParams) *gorm.DB {
+func paginate(db *gorm.DB, params QueryParams) *gorm.DB {
 	if params.All {
 		return db
 	}
@@ -159,11 +160,11 @@ func expressionByField(
 // Note: Don't forget to initialize DB Model first, otherwise filter and search won't work
 // Example:
 //
-//	db.Model(&UserModel).Scope(filter.FilterByQuery(ctx, filter.ALL)).Find(&users)
+//	db.Model(&UserModel).Scopes(filter.FilterByQueryParams(params, filter.ALL)).Find(&users)
 //
 // Or if only pagination and order is needed:
 //
-//	db.Model(&UserModel).Scope(filter.FilterByQuery(ctx, filter.PAGINATION|filter.ORDER_BY)).Find(&users)
+//	db.Model(&UserModel).Scopes(filter.FilterByQueryParams(params, filter.PAGINATE|filter.ORDER_BY)).Find(&users)
 //
 // And models should have appropriate`filter` tags:
 //
@@ -173,14 +174,8 @@ func expressionByField(
 //		// `param` defines custom column name for the query param
 //		FullName string `filter:"searchable"`
 //	}
-func FilterByQuery(c *gin.Context, config int) func(db *gorm.DB) *gorm.DB {
+func FilterByQueryParams(params QueryParams, config int) func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
-		var params queryParams
-		err := c.BindQuery(&params)
-		if err != nil {
-			return db
-		}
-
 		model := db.Statement.Model
 		modelType := reflect.TypeOf(model)
 		if model != nil && modelType.Kind() == reflect.Pointer && modelType.Elem().Kind() == reflect.Struct {
@@ -199,5 +194,21 @@ func FilterByQuery(c *gin.Context, config int) func(db *gorm.DB) *gorm.DB {
 			db = paginate(db, params)
 		}
 		return db
+	}
+}
+
+// FilterByQuery filters DB requests with query parameters from a Gin context.
+//
+// Deprecated: bind query parameters in the handler and use FilterByQueryParams
+// so BindQuery/ShouldBindQuery errors can be handled by the caller.
+func FilterByQuery(c *gin.Context, config int) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		var params QueryParams
+		err := c.BindQuery(&params)
+		if err != nil {
+			return db
+		}
+
+		return FilterByQueryParams(params, config)(db)
 	}
 }

--- a/gin-gorm-filter_test.go
+++ b/gin-gorm-filter_test.go
@@ -88,6 +88,36 @@ func (s *TestSuite) TestFiltersBasic() {
 	s.NoError(err)
 }
 
+func (s *TestSuite) TestFiltersByQueryParamsBasic() {
+	var users []User
+	params := QueryParams{
+		Filter:         []string{"login:sampleUser"},
+		Page:           1,
+		PageSize:       10,
+		OrderBy:        "id",
+		OrderDirection: "desc",
+	}
+
+	s.mock.ExpectQuery(`^SELECT \* FROM "users" WHERE "users"."username" = \$1 ORDER BY "id" DESC LIMIT \$2$`).
+		WithArgs("sampleUser", 10).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "username", "full_name", "email", "password"}))
+	err := s.db.Model(&User{}).Scopes(FilterByQueryParams(params, ALL)).Find(&users).Error
+	s.NoError(err)
+}
+
+func (s *TestSuite) TestQueryParamsBindingValidationCanBeHandledByCaller() {
+	ctx := gin.Context{}
+	ctx.Request = &http.Request{
+		URL: &url.URL{
+			RawQuery: "order_direction=sideways",
+		},
+	}
+
+	var params QueryParams
+	err := ctx.ShouldBindQuery(&params)
+	s.Error(err)
+}
+
 // TestFiltersBasic is a test for basic filters functionality.
 func (s *TestSuite) TestFiltersLike() {
 	var users []User


### PR DESCRIPTION
This change introduces a `QueryParams` API for building GORM scopes from already-bound request parameters, and keeps the existing Gin-context helper as a deprecated compatibility wrapper.

Closes #16 

What changed:
- Exported `QueryParams` so handlers can bind and validate query parameters themselves.
- Added `FilterByQueryParams(params, config)` as the primary entry point for filtering, pagination, and ordering.
- Kept `FilterByQuery(c, config)` as a deprecated wrapper that preserves old behavior.
- Tightened `order_direction` validation to use standard Gin binding tags.
- Updated the README to show binding query params in the handler, the new `PAGINATE` flag name, and the revised `page_size` request parameter.
- Added tests covering direct `QueryParams` usage and caller-handled binding validation.

Why:
- Callers can now handle binding/validation errors explicitly instead of having them swallowed inside the scope helper.
- The new API is easier to reuse in handlers and makes the filtering behavior more predictable.
- Documentation and tests were updated to match the new flow and parameter names.